### PR TITLE
Maint/update auxiliary data calls

### DIFF
--- a/src/gbd_mapping/__init__.py
+++ b/src/gbd_mapping/__init__.py
@@ -3,6 +3,6 @@ from .base_template import GbdRecord, ModelableEntity, Restrictions, Tmred, Leve
 from .cause import Cause, causes
 from .sequela import Sequela, Healthstate, sequelae
 from .etiology import Etiology, etiologies
-from .risk import Risk, risks
+from .risk import Risk, risk_factors
 from .covariate import Covariate, covariates
 from .coverage_gap import CoverageGap, coverage_gaps

--- a/src/gbd_mapping/base_template.py
+++ b/src/gbd_mapping/base_template.py
@@ -238,13 +238,11 @@ class Levels(GbdRecord):
 
 class ExposureParameters(GbdRecord):
     """Container for continuous risk exposure distribution parameters"""
-    __slots__ = ('dismod_id', 'scale', 'max_rr', )
+    __slots__ = ('scale', 'max_rr', )
 
     def __init__(self,
-                 dismod_id: meid = None,
                  scale: scalar = None,
                  max_rr: scalar = None, ):
         super().__init__()
-        self.dismod_id = dismod_id
         self.scale = scale
         self.max_rr = max_rr

--- a/src/gbd_mapping/coverage_gap.py
+++ b/src/gbd_mapping/coverage_gap.py
@@ -7,7 +7,7 @@ Any manual changes will be lost.
 from .base_template import Levels, Restrictions
 from .coverage_gap_template import CoverageGap, CoverageGaps
 from .cause import causes
-from .risk import risks
+from .risk import risk_factors
 
 
 coverage_gaps = CoverageGaps(

--- a/src/gbd_mapping/risk.py
+++ b/src/gbd_mapping/risk.py
@@ -10,7 +10,7 @@ from .risk_template import Risk, Risks
 from .cause import causes
 
 
-risks = Risks(
+risk_factors = Risks(
     unsafe_water_source=Risk(
         name='unsafe_water_source',
         gbd_id=reiid(83),
@@ -103,7 +103,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=None,
             scale=scalar(10.0),
             max_rr=scalar(100.0),
         ),
@@ -126,7 +125,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18685),
             scale=scalar(1.0),
             max_rr=scalar(10000.0),
         ),
@@ -168,7 +166,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(10488),
             scale=scalar(10.0),
             max_rr=scalar(5000.0),
         ),
@@ -273,7 +270,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(15789),
             scale=scalar(1.0),
             max_rr=scalar(10.0),
         ),
@@ -296,7 +292,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(15788),
             scale=scalar(10.0),
             max_rr=scalar(200.0),
         ),
@@ -327,7 +322,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18706),
             scale=scalar(5.0),
             max_rr=scalar(50.0),
         ),
@@ -365,7 +359,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(2444),
             scale=scalar(0.1),
             max_rr=scalar(5.0),
         ),
@@ -392,7 +385,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18689),
             scale=scalar(100.0),
             max_rr=scalar(400.0),
         ),
@@ -418,7 +410,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18690),
             scale=scalar(100.0),
             max_rr=scalar(450.0),
         ),
@@ -441,7 +432,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18692),
             scale=scalar(50.0),
             max_rr=scalar(150.0),
         ),
@@ -465,7 +455,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18693),
             scale=scalar(4.05),
             max_rr=scalar(24.0),
         ),
@@ -488,7 +477,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18694),
             scale=scalar(226.8),
             max_rr=scalar(680.0),
         ),
@@ -511,7 +499,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18695),
             scale=scalar(100.0),
             max_rr=scalar(1000.0),
         ),
@@ -534,7 +521,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18696),
             scale=scalar(50.0),
             max_rr=scalar(1000.0),
         ),
@@ -557,7 +543,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=None,
             scale=scalar(226.8),
             max_rr=scalar(5000.0),
         ),
@@ -595,7 +580,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18697),
             scale=scalar(20.0),
             max_rr=scalar(32.0),
         ),
@@ -618,7 +602,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18699),
             scale=scalar(100.0),
             max_rr=scalar(1000.0),
         ),
@@ -641,7 +624,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18700),
             scale=scalar(0.05),
             max_rr=scalar(0.149),
         ),
@@ -664,7 +646,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18702),
             scale=scalar(0.02),
             max_rr=scalar(1.0),
         ),
@@ -687,7 +668,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18703),
             scale=scalar(1.0),
             max_rr=scalar(50.0),
         ),
@@ -718,7 +698,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18704),
             scale=scalar(600.0),
             max_rr=scalar(5000.0),
         ),
@@ -907,7 +886,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18705),
             scale=scalar(1.0),
             max_rr=scalar(30.0),
         ),
@@ -956,7 +934,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18698),
             scale=scalar(1.0),
             max_rr=scalar(50.0),
         ),
@@ -1392,7 +1369,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=None,
             scale=scalar(1.0),
             max_rr=UNKNOWN,
         ),
@@ -1415,7 +1391,6 @@ risks = Risks(
             inverted=False,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18687),
             scale=scalar(10.0),
             max_rr=scalar(500.0),
         ),
@@ -1494,7 +1469,6 @@ risks = Risks(
             inverted=True,
         ),
         exposure_parameters=ExposureParameters(
-            dismod_id=meid(18691),
             scale=scalar(50.0),
             max_rr=scalar(450.0),
         ),

--- a/src/gbd_mapping/risk_template.py
+++ b/src/gbd_mapping/risk_template.py
@@ -13,8 +13,8 @@ from .cause_template import Cause
 
 class Risk(ModelableEntity):
     """Container for risk GBD ids and metadata."""
-    __slots__ = ('name', 'gbd_id', 'distribution', 'affected_causes', 'restrictions', 'using_2017_data', 'levels',
-                 'tmred', 'exposure_parameters', )
+    __slots__ = ('name', 'gbd_id', 'distribution', 'affected_causes', 'restrictions', 'levels', 'tmred',
+                 'exposure_parameters', )
 
     def __init__(self,
                  name: str,
@@ -22,7 +22,6 @@ class Risk(ModelableEntity):
                  distribution: str,
                  affected_causes: Tuple[Cause, ...],
                  restrictions: Restrictions,
-                 using_2017_data: bool,
                  levels: Levels = None,
                  tmred: Tmred = None,
                  exposure_parameters: ExposureParameters = None, ):
@@ -33,7 +32,6 @@ class Risk(ModelableEntity):
         self.distribution = distribution
         self.affected_causes = affected_causes
         self.restrictions = restrictions
-        self.using_2017_data = using_2017_data
         self.levels = levels
         self.tmred = tmred
         self.exposure_parameters = exposure_parameters

--- a/src/gbd_mapping/risk_template.py
+++ b/src/gbd_mapping/risk_template.py
@@ -13,8 +13,8 @@ from .cause_template import Cause
 
 class Risk(ModelableEntity):
     """Container for risk GBD ids and metadata."""
-    __slots__ = ('name', 'gbd_id', 'distribution', 'affected_causes', 'restrictions', 'levels', 'tmred',
-                 'exposure_parameters', )
+    __slots__ = ('name', 'gbd_id', 'distribution', 'affected_causes', 'restrictions', 'using_2017_data', 'levels',
+                 'tmred', 'exposure_parameters', )
 
     def __init__(self,
                  name: str,
@@ -22,6 +22,7 @@ class Risk(ModelableEntity):
                  distribution: str,
                  affected_causes: Tuple[Cause, ...],
                  restrictions: Restrictions,
+                 using_2017_data: bool,
                  levels: Levels = None,
                  tmred: Tmred = None,
                  exposure_parameters: ExposureParameters = None, ):
@@ -32,6 +33,7 @@ class Risk(ModelableEntity):
         self.distribution = distribution
         self.affected_causes = affected_causes
         self.restrictions = restrictions
+        self.using_2017_data = using_2017_data
         self.levels = levels
         self.tmred = tmred
         self.exposure_parameters = exposure_parameters

--- a/src/gbd_mapping_generator/base_template_builder.py
+++ b/src/gbd_mapping_generator/base_template_builder.py
@@ -19,8 +19,7 @@ tmred_attrs = (('distribution', 'str'),
                ('max', 'scalar'),
                ('inverted', 'bool'),)
 levels_attrs = tuple([('cat1', 'str'), ('cat2', 'str')] + [(f'cat{i}', 'str = None') for i in range(3, 60)])
-exposure_parameters_attrs = (('dismod_id', 'meid = None'),
-                             ('scale', 'scalar = None'),
+exposure_parameters_attrs = (('scale', 'scalar = None'),
                              ('max_rr', 'scalar = None'),)
 
 

--- a/src/gbd_mapping_generator/build_mapping.py
+++ b/src/gbd_mapping_generator/build_mapping.py
@@ -50,8 +50,8 @@ def build_mapping(mapping_type, with_debugger):
             import traceback
             traceback.print_exc()
             pdb.post_mortem()
-
-
+        else:
+            raise
 
 
 def make_dirs_and_init(mapping_type):

--- a/src/gbd_mapping_generator/coverage_gap_builder.py
+++ b/src/gbd_mapping_generator/coverage_gap_builder.py
@@ -112,6 +112,6 @@ def build_mapping():
     out += make_import('.base_template', ['Levels', 'Restrictions'])
     out += make_import('.coverage_gap_template', ['CoverageGap', 'CoverageGaps'])
     out += make_import('.cause', ['causes'])
-    out += make_import('.risk', ['risks']) + SPACING
+    out += make_import('.risk', ['risk_factors']) + SPACING
     out += make_coverage_gaps(get_coverage_gap_data())
     return out

--- a/src/gbd_mapping_generator/data.py
+++ b/src/gbd_mapping_generator/data.py
@@ -159,7 +159,7 @@ def get_cause_data():
 
 def load_risk_params():
     # Read in our parameter data sheet and filter out etiologies/aggregate risks/impairments
-    risk_params = gbd.get_data_from_auxiliary_file('Risk Data', gbd_round='GBD_2016')
+    risk_params = gbd.get_auxiliary_data(measure='metadata', entity_type='risk_factor', entity_name='risk_variables')
     risk_params = risk_params[~np.isnan(risk_params.rei_id)]
 
     risk_params.loc[risk_params.risk_type == 0, 'calc_type'] = 'unknown'
@@ -195,9 +195,6 @@ def get_cause_risk_mapping():
 
 def get_risk_data():
     risks = load_risk_params()
-    # FIXME: This is here until exposure standard deviations are available by rei id instead of just meid -J.C.
-    exposure_sd_map = gbd.get_data_from_auxiliary_file(
-        'Risk Standard Deviation Meids').set_index('rei_id')['modelable_entity_id']
     cause_risk_mapping = get_cause_risk_mapping()
 
     out = []
@@ -228,9 +225,7 @@ def get_risk_data():
                      ('min', risk['tmred_para1']),
                      ('max', risk['tmred_para2']),
                      ('inverted', inv_exp))
-            dismod_id = exposure_sd_map[rid] if rid in exposure_sd_map.index else None
-            exp_params = (('dismod_id', dismod_id),
-                          ('scale', risk['rr_scalar']),
+            exp_params = (('scale', risk['rr_scalar']),
                           ('max_rr', risk['maxrr']),)
 
         elif r.dichotomous:

--- a/src/gbd_mapping_generator/data.py
+++ b/src/gbd_mapping_generator/data.py
@@ -312,7 +312,7 @@ def get_coverage_gap_data():
     out = []
 
     for c in gbd.get_coverage_gap_list():
-        metadata = get_coverage_gap_metadata(c)
+        metadata = get_coverage_gap_metadata(c)['exposure']
         restrictions = tuple((k, v) for k, v in metadata['restrictions'].items())
         levels = tuple((k, v) for k, v in metadata['levels'].items())
         out.append((c, metadata['distribution'], restrictions, levels,

--- a/src/gbd_mapping_generator/risk_builder.py
+++ b/src/gbd_mapping_generator/risk_builder.py
@@ -17,7 +17,6 @@ base_types = {
                   ('distribution', 'str'),
                   ('affected_causes', 'Tuple[Cause, ...]'),
                   ('restrictions', 'Restrictions'),
-                  ('using_2017_data', 'bool'),
                   ('levels', 'Levels = None'),
                   ('tmred', 'Tmred = None'),
                   ('exposure_parameters', 'ExposureParameters = None'),),

--- a/src/gbd_mapping_generator/risk_builder.py
+++ b/src/gbd_mapping_generator/risk_builder.py
@@ -7,7 +7,7 @@ from .base_template_builder import modelable_entity_attrs, gbd_record_attrs
 from .util import make_import, make_module_docstring, make_record, SPACING, TAB, TEXTWIDTH
 
 
-IMPORTABLES_DEFINED = ('Risk', 'risks')
+IMPORTABLES_DEFINED = ('Risk', 'risk_factors')
 
 
 base_types = {
@@ -86,7 +86,7 @@ def make_risk(name, reiid, distribution, restrictions, cause_list,
 
 
 def make_risks(riskfactor_data):
-    out = "risks = Risks(\n"
+    out = "risk_factors = Risks(\n"
     for name, reiid, distribution, restrictions, cause_list, levels, tmred, exposure_parameters in riskfactor_data:
         out += make_risk(name, reiid, distribution, restrictions, cause_list,
                                 levels, tmred, exposure_parameters)


### PR DESCRIPTION
- Changed calls to reflect structure of new auxiliary data
- rolled back rename of risk mapping from `risk_factors` to `risks`.  That was a bad idea.
- removed dismod_id from exposure parameters, exposured_sds are callable from get_draws
- removed unused `using_2017_data` flag from mapping generator
- added extra raise clause to mapping generator so things don't fail silently.