### PR TITLE
rebuild coverage_gaps

### DIFF
--- a/src/gbd_mapping/coverage_gap.py
+++ b/src/gbd_mapping/coverage_gap.py
@@ -12,6 +12,24 @@ from .risk_factor import risk_factors
 
 
 coverage_gaps = CoverageGaps(
+    lack_of_eggs=CoverageGap(
+        name='lack_of_eggs',
+        kind='coverage_gap',
+        gbd_id=None,
+        distribution='dichotomous',
+        restrictions=Restrictions(
+            female_only=False,
+            male_only=False,
+            yld_only=False,
+            yll_only=False,
+        ),
+        categories=Categories(
+            cat1='exposed',
+            cat2='unexposed',
+        ),
+        affected_causes=(),
+        affected_risk_factors=(risk_factors.child_underweight, risk_factors.child_stunting, ),
+    ),
     lack_of_vitamin_a_fortification=CoverageGap(
         name='lack_of_vitamin_a_fortification',
         kind='coverage_gap',
@@ -29,5 +47,23 @@ coverage_gaps = CoverageGaps(
         ),
         affected_causes=(),
         affected_risk_factors=(risk_factors.vitamin_a_deficiency, ),
+    ),
+    lack_of_breastfeeding_promotion=CoverageGap(
+        name='lack_of_breastfeeding_promotion',
+        kind='coverage_gap',
+        gbd_id=None,
+        distribution='dichotomous',
+        restrictions=Restrictions(
+            female_only=False,
+            male_only=False,
+            yld_only=False,
+            yll_only=False,
+        ),
+        categories=Categories(
+            cat1='exposed',
+            cat2='unexposed',
+        ),
+        affected_causes=(),
+        affected_risk_factors=(risk_factors.discontinued_breastfeeding, risk_factors.non_exclusive_breastfeeding, ),
     ),
 )

--- a/src/gbd_mapping/coverage_gap_template.py
+++ b/src/gbd_mapping/coverage_gap_template.py
@@ -39,9 +39,13 @@ class CoverageGap(GbdRecord):
 
 class CoverageGaps(GbdRecord):
     """Container for coverage gap data."""
-    __slots__ = ('lack_of_vitamin_a_fortification', )
+    __slots__ = ('lack_of_breastfeeding_promotion', 'lack_of_eggs', 'lack_of_vitamin_a_fortification', )
 
     def __init__(self,
+                 lack_of_breastfeeding_promotion: CoverageGap,
+                 lack_of_eggs: CoverageGap,
                  lack_of_vitamin_a_fortification: CoverageGap, ):
         super().__init__()
+        self.lack_of_breastfeeding_promotion = lack_of_breastfeeding_promotion
+        self.lack_of_eggs = lack_of_eggs
         self.lack_of_vitamin_a_fortification = lack_of_vitamin_a_fortification


### PR DESCRIPTION
after relocating some data and rerun the build mapping based on what we actually have in 2017 folder. BFP is guaranteed to have the shape that we want to have. But I don't look inside the other two. I'm not even sure whether we need lack_of_eggs since it wasn't there and the model seems to work without it. So let me know if we don't want to have it yet. 