### PR TITLE
Develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} >> $GITHUB_OUTPUT
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Print environment values
         run: |
-          cat $GITHUB_ENV
+          cat $GITHUB_ENV >> $GITHUB_OUTPUT
       - name: Update pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
         python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }} >> $GITHUB_OUTPUT
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}        
       - name: Print environment values
         run: |
-          cat $GITHUB_ENV >> $GITHUB_OUTPUT
+          cat $GITHUB_ENV
       - name: Update pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Print environment values
         run: |
           echo "Python Version ${{ matrix.python-version }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Print environment values
         run: |
-          echo "Python Version ${{ matrix.python-version }}"
+          python --version
           cat $GITHUB_ENV
       - name: Update pip
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,11 @@ jobs:
         python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }} >> $GITHUB_OUTPUT
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }} >> $GITHUB_OUTPUT
+          python-version: "${{ matrix.python-version }}"
+          run: echo "Python Version ${{ matrix.python-version }}" >> $GITHUB_OUTPUT
       - name: Print environment values
         run: |
           cat $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Print environment values

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
         python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }} >> $GITHUB_OUTPUT
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}        
+          python-version: ${{ matrix.python-version }} >> $GITHUB_OUTPUT
       - name: Print environment values
         run: |
           cat $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, "3.10"]
+        python-version: [3.7, 3,8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 #   - invoked on push, pull_request, or manual trigger
-#   - test under 3 versions of python
+#   - test under n-1,n,n+1 (at least 3) versions of python
 # -----------------------------------------------------------------------------
 name: build
 on: [push, pull_request, workflow_dispatch]
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3,8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
-        with:
-          python-version: "${{ matrix.python-version }}"
-          run: echo "Python Version ${{ matrix.python-version }}" >> $GITHUB_OUTPUT
       - name: Print environment values
         run: |
+          echo "Python Version ${{ matrix.python-version }}"
           cat $GITHUB_ENV
       - name: Update pip
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,8 @@
 name: deploy
 
 on: 
-  workflow_dispatch: {}
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -23,4 +24,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist bdist_wheel
-          # twine upload dist/*
+          twine upload dist/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: deploy
 
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch: {}
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: deploy
 
-on: 
+on:
   release:
     types: [published]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.8'
       - name: Install dependencies
@@ -23,4 +23,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+          # twine upload dist/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: deploy
 
 on: [workflow_dispatch]
-  # release:
-    # types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: deploy
 
-on:
-  [workflow_dispatch]
+on: [workflow_dispatch]
   # release:
     # types: [published]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Install dependencies
         run: |
+          python --version
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
       - name: Build and publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: deploy
 
 on:
-  release:
-    types: [published]
+  [workflow_dispatch]
+  # release:
+    # types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
## Title: Deprecated actions and commands in automatic builds on Github

### Description
Updated setup-python version to remove warning
Added python actual version in use for logging
Updated deploy.yaml with corresponding changes
- *Category*: CI/infrastructure
- *JIRA issue*: [MIC-3530](https://jira.ihme.washington.edu/browse/MIC-3530)

### Changes and notes
Changes to workflow files to remove warning due to deprecated usage.

### Testing
Tested by commenting out twine upload for deploy, adding workflow-submit event and then changing default branch on fork.
https://github.com/ramittal/gbd_mapping/actions/runs/3762396088


