### PR TITLE
Mic-4384/Notify on workflow failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,4 +68,5 @@ jobs:
           # comma-separated string, send email to
           to: uw_ihme_simulationscience@uw.edu
           # from email name
-          from: Dr Manhattan
+          from: Vivarium Notifications
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,22 @@ jobs:
       - name: Doctest
         run: |
           make doctest -C docs/
+      - name: Send mail
+        # Notify when cron job fails
+        if: (github.event_name == 'schedule' && failure())
+        uses: dawidd6/action-send-mail@v2
+        with:
+          # mail server settings
+          server_address: smtp.gmail.com
+          server_port: 465
+          # user credentials
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.NOTIFY_PASSWORD }}
+          # email subject
+          subject: ${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}
+          # email body as text
+          body: ${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has ${{ job.status }}
+          # comma-separated string, send email to
+          to: uw_ihme_simulationscience@uw.edu
+          # from email name
+          from: Dr Manhattan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,22 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           twine upload dist/*
+      - name: Send mail
+        # Notify when cron job fails
+        if: failure()
+        uses: dawidd6/action-send-mail@v2
+        with:
+          # mail server settings
+          server_address: smtp.gmail.com
+          server_port: 465
+          # user credentials
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.NOTIFY_PASSWORD }}
+          # email subject
+          subject: ${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}
+          # email body as text
+          body: ${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has ${{ job.status }}
+          # comma-separated string, send email to
+          to: uw_ihme_simulationscience@uw.edu
+          # from email name
+          from: Dr Manhattan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,4 +47,5 @@ jobs:
           # comma-separated string, send email to
           to: uw_ihme_simulationscience@uw.edu
           # from email name
-          from: Dr Manhattan
+          from: Vivarium Notifications
+          


### PR DESCRIPTION
## Mic-4384/Notify on workflow failure

### Sends email notification on schedule or deploy workflow failure
- *Category*: CI
- *JIRA issue*: [MIC-4384](https://jira.ihme.washington.edu/browse/MIC-4384)

### Changes and notes
-Sends email notification when schedule or deploy workflows fail

### Testing
Received email when pushing broken build.
