### PR TITLE
Fix infinite recursion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**4.1.2 - 12/3/24**
+
+ - Fix infinite recursion bug
+
 **4.1.1 - 12/2/24**
 
  - Properly clean up Jenkins workspaces

--- a/src/gbd_mapping/base_template.py
+++ b/src/gbd_mapping/base_template.py
@@ -16,7 +16,7 @@ class GbdRecord:
         for item in self.__slots__:
             attr = getattr(self, item)
             if item == "parent":
-                out[item] = attr
+                out[item] = attr.name if hasattr(attr, "name") else attr.__repr__()
             elif isinstance(attr, GbdRecord):
                 out[item] = attr.to_dict()
             elif isinstance(attr, tuple) and attr:

--- a/src/gbd_mapping/base_template.py
+++ b/src/gbd_mapping/base_template.py
@@ -10,12 +10,14 @@ from .id import c_id, cov_id, hs_id, me_id, rei_id, s_id, scalar
 class GbdRecord:
     """Base class for entities modeled in the GBD."""
     __slots__ = ()
-    
+
     def to_dict(self):
         out = {}
         for item in self.__slots__:
             attr = getattr(self, item)
-            if isinstance(attr, GbdRecord):
+            if item == "parent":
+                out[item] = attr
+            elif isinstance(attr, GbdRecord):
                 out[item] = attr.to_dict()
             elif isinstance(attr, tuple) and attr:
                 if isinstance(attr[0], GbdRecord):
@@ -38,7 +40,7 @@ class GbdRecord:
     def __iter__(self):
         for item in self.__slots__:
             yield getattr(self, item)
-            
+
     def __eq__(self, other):
         return all([getattr(self, item) == getattr(other, item) for item in self.__slots__
                     if not isinstance(getattr(self, item), GbdRecord)])

--- a/tests/test_base_template.py
+++ b/tests/test_base_template.py
@@ -1,0 +1,17 @@
+from gbd_mapping.base_template import GbdRecord
+
+
+class TestGbdRecord(GbdRecord):
+    __slots__ = ("name", "parent")
+
+    def __init__(self, name, parent=None):
+        super().__init__()
+        self.name = name
+        self.parent = parent
+
+
+def test_to_dict():
+    record = TestGbdRecord(name="record1")
+    record2 = TestGbdRecord(name="record2", parent=record)
+    record.parent = record2
+    record.to_dict()


### PR DESCRIPTION
## Fix infinite recursion
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
When you call `to_dict()` on a GBD Mapping entity, it tries to create an infinitely deep tree - since the graph relationship is cyclic - and throws an error: `RecursionError: maximum recursion depth exceeded`. 
I made it so that the parent attribute fills in the dictionary as the name or repr instead of the full to_dict().

The IDs actually inherit from `int`, so you can see them when you make the dictionary, even though it technically wraps them in e.g. `c_id(1025)`. I think this is OK as is.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
added unit test
